### PR TITLE
Fix use of pkgconfig in configure.in

### DIFF
--- a/stklos/configure.in
+++ b/stklos/configure.in
@@ -29,8 +29,8 @@ VERSION=1.0.0
 PACKAGE=stklos-gtk-canvas
 
 dnl test if libgoocanvas exists
-if pkg-config --exists goocanvas 2> /dev/null
-then 
+if [[ $(pkg-config --exists goocanvas-2.0 2> /dev/null) ]] -o [[ $(pkg-config --exists goocanvas 2> /dev/null) ]]
+then
      GOOCANVAS="present"
      CFLAGS="$CFLAGS -DHAVE_GOO `pkg-config goocanvas --cflags --libs`"
 else


### PR DESCRIPTION
Hello @egallesio !
I did not fully test this, because stklos-pkg uses the repository instead of local copies, but on both Suse, Debian and FreeBSD, and Arch this works:

```
pkg-config --exists goocanvas-2.0
echo $?
1
```

and this does not:

```
pkg-config --exists goocanvas
echo $?
0
```
